### PR TITLE
added attr('target','_blank') to var linkDiv

### DIFF
--- a/assets/javascript/coinmarket.js
+++ b/assets/javascript/coinmarket.js
@@ -121,8 +121,8 @@ $(document).ready(function() {
                     var descDiv = $("<div>").text(desc);
 
                     var sourceDiv = $("<div>").text(src);
-                    
-                    var linkDiv = $("<a>").attr("href", articleURL);
+                    //Rie's comment : I added attr("target","_blank") to open an article in a new tab. 
+                    var linkDiv = $("<a>").attr("href", articleURL).attr("target","_blank");
                     
 
                     var imgDiv = $("<img>").attr({


### PR DESCRIPTION
Added attr("target","_blank") in coinmarket.js to open an article in a new tab when the link is clicked.

var linkDiv = $("<a>").attr("href", articleURL).attr("target","_blank");
![image](https://user-images.githubusercontent.com/37225235/42399469-ea4b8f98-813b-11e8-8caa-57910065ae92.png)

                    